### PR TITLE
Publish artifacts & added log file content type

### DIFF
--- a/s3-artifact-storage-agent/src/main/java/jetbrains/buildServer/artifacts/s3/publish/S3ArtifactsPublisher.java
+++ b/s3-artifact-storage-agent/src/main/java/jetbrains/buildServer/artifacts/s3/publish/S3ArtifactsPublisher.java
@@ -29,6 +29,7 @@ public class S3ArtifactsPublisher implements ArtifactsPublisher {
 
   private final CurrentBuildTracker myTracker;
   private final AgentArtifactHelper myHelper;
+  private AgentRunningBuild myBuild;
 
   private List<ArtifactDataInstance> myArtifacts = new ArrayList<ArtifactDataInstance>();
   private S3FileUploader myFileUploader;
@@ -43,11 +44,7 @@ public class S3ArtifactsPublisher implements ArtifactsPublisher {
       public void buildStarted(@NotNull AgentRunningBuild runningBuild) {
         myFileUploader = null;
         myArtifacts.clear();
-      }
-
-      @Override
-      public void afterAtrifactsPublished(@NotNull AgentRunningBuild runningBuild, @NotNull BuildFinishedStatus status) {
-        publishArtifactsList(runningBuild);
+        myBuild = runningBuild;
       }
     });
   }
@@ -66,6 +63,7 @@ public class S3ArtifactsPublisher implements ArtifactsPublisher {
       final String pathPrefix = getPathPrefix(build);
       final S3FileUploader fileUploader = getFileUploader(build);
       myArtifacts.addAll(fileUploader.publishFiles(build, pathPrefix, filteredMap));
+      publishArtifactsList(myBuild);
     }
 
     return filteredMap.size();

--- a/s3-artifact-storage-common/src/main/java/jetbrains/buildServer/artifacts/s3/S3Util.java
+++ b/s3-artifact-storage-common/src/main/java/jetbrains/buildServer/artifacts/s3/S3Util.java
@@ -24,6 +24,7 @@ import static jetbrains.buildServer.artifacts.s3.S3Constants.S3_BUCKET_NAME;
 public class S3Util {
 
   private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
+  private static final String TEXT_CONTENT_TYPE = "text/plain";
 
   @NotNull
   public static Map<String, String> validateParameters(@NotNull Map<String, String> params, boolean acceptReferences) {
@@ -89,7 +90,8 @@ public class S3Util {
   }
 
   public static String getContentType(File file) {
-    return StringUtil.notEmpty(URLConnection.guessContentTypeFromName(file.getName()), DEFAULT_CONTENT_TYPE);
+    return file.getName().endsWith(".log") ? TEXT_CONTENT_TYPE :
+      StringUtil.notEmpty(URLConnection.guessContentTypeFromName(file.getName()), DEFAULT_CONTENT_TYPE);
   }
 
   public static String normalizeArtifactPath(final String path, final File file) {


### PR DESCRIPTION
- Published the artifacts list to UI once the files are copied to S3, will help to view/download the intermediate artifacts while build is still running.
- Added content type for .log files so that will be displayed in browser instead of download prompt.