### PR TITLE
Add CloudFront upload distribution support

### DIFF
--- a/s3-artifact-storage-server/kotlin-dsl/S3StorageSettings.xml
+++ b/s3-artifact-storage-server/kotlin-dsl/S3StorageSettings.xml
@@ -76,6 +76,11 @@
         Name of CloudFront distribution for uploads
       </description>
     </param>
+    <param name="storage.s3.cloudfront.upload.s3.enabled" dslName="cloudFrontUseS3Upload" type="boolean" trueValue="true" falseValue="">
+      <description>
+        Whether to upload artifacts directly to S3 while using CloudFront for downloads
+      </description>
+    </param>
     <param name="storage.s3.cloudfront.download.distribution" dslName="cloudFrontDownloadDistribution" type="string">
       <description>
         Name of CloudFront distribution for downloads

--- a/s3-artifact-storage-server/src/main/java/jetbrains/buildServer/artifacts/s3/CloudFrontS3UploadSettings.java
+++ b/s3-artifact-storage-server/src/main/java/jetbrains/buildServer/artifacts/s3/CloudFrontS3UploadSettings.java
@@ -1,0 +1,16 @@
+package jetbrains.buildServer.artifacts.s3;
+
+import java.util.Map;
+import jetbrains.buildServer.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+
+public final class CloudFrontS3UploadSettings {
+  public static final String S3_CLOUDFRONT_UPLOAD_USE_S3 = "storage.s3.cloudfront.upload.s3.enabled";
+
+  private CloudFrontS3UploadSettings() {
+  }
+
+  public static boolean useS3ForUpload(@NotNull Map<String, String> params) {
+    return StringUtil.isTrue(params.get(S3_CLOUDFRONT_UPLOAD_USE_S3));
+  }
+}

--- a/s3-artifact-storage-server/src/main/java/jetbrains/buildServer/artifacts/s3/settings/CloudFrontPropertiesProcessor.java
+++ b/s3-artifact-storage-server/src/main/java/jetbrains/buildServer/artifacts/s3/settings/CloudFrontPropertiesProcessor.java
@@ -4,6 +4,7 @@ import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import jetbrains.buildServer.artifacts.s3.CloudFrontS3UploadSettings;
 import jetbrains.buildServer.artifacts.s3.S3Util;
 import jetbrains.buildServer.artifacts.s3.ValidateCloudFrontKeys;
 import jetbrains.buildServer.serverSide.InvalidProperty;
@@ -18,7 +19,8 @@ public class CloudFrontPropertiesProcessor implements PropertiesProcessor {
   public Collection<InvalidProperty> process(Map<String, String> params) {
     final ArrayList<InvalidProperty> invalids = new ArrayList<>();
 
-    if (StringUtil.isEmptyOrSpaces(S3Util.getCloudFrontUploadDistribution(params))) {
+    if (!CloudFrontS3UploadSettings.useS3ForUpload(params) &&
+        StringUtil.isEmptyOrSpaces(S3Util.getCloudFrontUploadDistribution(params))) {
       invalids.add(new InvalidProperty(S3_CLOUDFRONT_UPLOAD_DISTRIBUTION, "CloudFront distribution for upload should not be empty"));
     }
 

--- a/s3-artifact-storage-server/src/main/java/jetbrains/buildServer/artifacts/s3/web/S3ParametersProvider.java
+++ b/s3-artifact-storage-server/src/main/java/jetbrains/buildServer/artifacts/s3/web/S3ParametersProvider.java
@@ -5,6 +5,7 @@ package jetbrains.buildServer.artifacts.s3.web;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import jetbrains.buildServer.artifacts.s3.CloudFrontS3UploadSettings;
 import jetbrains.buildServer.artifacts.s3.S3Constants;
 import jetbrains.buildServer.artifacts.s3.cloudfront.CloudFrontConstants;
 import jetbrains.buildServer.clouds.amazon.connector.utils.parameters.AwsCloudConnectorConstants;
@@ -64,6 +65,10 @@ public class S3ParametersProvider {
 
   public String getCloudFrontUploadDistribution() {
     return CloudFrontConstants.S3_CLOUDFRONT_UPLOAD_DISTRIBUTION;
+  }
+
+  public String getCloudFrontUploadUseS3() {
+    return CloudFrontS3UploadSettings.S3_CLOUDFRONT_UPLOAD_USE_S3;
   }
 
   public String getCloudFrontDownloadDistribution() {

--- a/s3-artifact-storage-server/src/main/java/jetbrains/buildServer/artifacts/s3/web/S3PreSignedUrlController.java
+++ b/s3-artifact-storage-server/src/main/java/jetbrains/buildServer/artifacts/s3/web/S3PreSignedUrlController.java
@@ -17,10 +17,14 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import jetbrains.buildServer.BuildAuthUtil;
 import jetbrains.buildServer.artifacts.ServerArtifactStorageSettingsProvider;
+import jetbrains.buildServer.artifacts.s3.CloudFrontS3UploadSettings;
 import jetbrains.buildServer.artifacts.s3.PresignedUrlWithTtl;
 import jetbrains.buildServer.artifacts.s3.S3ArtifactUtil;
 import jetbrains.buildServer.artifacts.s3.S3Constants;
+import jetbrains.buildServer.artifacts.s3.S3PresignedUrlProvider;
+import jetbrains.buildServer.artifacts.s3.S3Settings;
 import jetbrains.buildServer.artifacts.s3.S3Util;
+import jetbrains.buildServer.artifacts.s3.cloudfront.CloudFrontConstants;
 import jetbrains.buildServer.artifacts.s3.cloudfront.CloudFrontEnabledPresignedUrlProvider;
 import jetbrains.buildServer.artifacts.s3.cloudfront.CloudFrontSettings;
 import jetbrains.buildServer.artifacts.s3.cloudfront.RequestMetadata;
@@ -65,6 +69,8 @@ public class S3PreSignedUrlController extends BaseController {
   @NotNull
   private final CloudFrontEnabledPresignedUrlProvider myPreSignedManager;
   @NotNull
+  private final S3PresignedUrlProvider myS3PreSignedManager;
+  @NotNull
   private final ServerArtifactStorageSettingsProvider myStorageSettingsProvider;
   @NotNull
   private final ProjectManagerEx myProjectManager;
@@ -72,10 +78,12 @@ public class S3PreSignedUrlController extends BaseController {
   public S3PreSignedUrlController(@NotNull WebControllerManager web,
                                   @NotNull RunningBuildsManagerEx runningBuildsManager,
                                   @NotNull CloudFrontEnabledPresignedUrlProvider preSignedManager,
+                                  @NotNull S3PresignedUrlProvider s3PreSignedManager,
                                   @NotNull ServerArtifactStorageSettingsProvider storageSettingsProvider,
                                   @NotNull ProjectManagerEx projectManager) {
     myRunningBuildsManager = runningBuildsManager;
     myPreSignedManager = preSignedManager;
+    myS3PreSignedManager = s3PreSignedManager;
     myStorageSettingsProvider = storageSettingsProvider;
     myProjectManager = projectManager;
     web.registerController(ARTEFACTS_S3_UPLOAD_PRESIGN_URLS_HTML, this);
@@ -111,14 +119,14 @@ public class S3PreSignedUrlController extends BaseController {
         throw new HttpServerErrorException(HttpStatus.UNAUTHORIZED, "Invalid credentials provided");
       }
 
-      final Pair<RequestType, CloudFrontSettings> request = parseRequest(httpServletRequest, runningBuild);
+      final Pair<RequestType, PresignedUrlSettings> request = parseRequest(httpServletRequest, runningBuild);
 
       httpServletResponse.setContentType("application/xml; charset=" + StandardCharsets.UTF_8.name());
       if (request.getFirst() == RequestType.FINISH_MULTIPART_UPLOAD) {
         finishMultipartUpload(httpServletRequest, request.getSecond());
         httpServletResponse.setStatus(HttpServletResponse.SC_OK);
       } else {
-        final CloudFrontSettings settings = request.getSecond();
+        final PresignedUrlSettings settings = request.getSecond();
         final PresignedUrlListRequestDto urlsRequest = PresignedUrlRequestSerializer.deserializeRequest(StreamUtil.readTextFrom(httpServletRequest.getReader()));
 
         if(TeamCityProperties.getBooleanOrTrue(S3_VALIDATE_KEYS))
@@ -220,7 +228,7 @@ public class S3PreSignedUrlController extends BaseController {
   }
 
   @NotNull
-  private Pair<RequestType, CloudFrontSettings> parseRequest(@NotNull final HttpServletRequest request, RunningBuildEx runningBuild) {
+  private Pair<RequestType, PresignedUrlSettings> parseRequest(@NotNull final HttpServletRequest request, RunningBuildEx runningBuild) {
     final Map<String, String> storageSettings = myStorageSettingsProvider.getStorageSettings(runningBuild);
     try {
       S3Util.validateParameters(storageSettings);
@@ -243,19 +251,36 @@ public class S3PreSignedUrlController extends BaseController {
       projectParameters.putAll(project.getParameters());
     }
 
-    return Pair.create(RequestType.fromRequest(request), myPreSignedManager.settings(storageSettings, projectParameters, RequestMetadata.from(requestRegion, userAgent)));
+    return Pair.create(RequestType.fromRequest(request), new PresignedUrlSettings(
+      myPreSignedManager.settings(cloudFrontSettings(storageSettings), projectParameters, RequestMetadata.from(requestRegion, userAgent)),
+      myS3PreSignedManager.settings(storageSettings, projectParameters),
+      CloudFrontS3UploadSettings.useS3ForUpload(storageSettings)
+    ));
+  }
+
+  @NotNull
+  private Map<String, String> cloudFrontSettings(@NotNull Map<String, String> storageSettings) {
+    if (!CloudFrontS3UploadSettings.useS3ForUpload(storageSettings) ||
+        StringUtil.isNotEmpty(S3Util.getCloudFrontUploadDistribution(storageSettings))) {
+      return storageSettings;
+    }
+
+    Map<String, String> normalizedSettings = new HashMap<>(storageSettings);
+    normalizedSettings.put(CloudFrontConstants.S3_CLOUDFRONT_UPLOAD_DISTRIBUTION,
+                           StringUtil.emptyIfNull(S3Util.getCloudFrontDownloadDistribution(storageSettings)));
+    return normalizedSettings;
   }
 
   @NotNull
   private String presignedUrlsV2(@NotNull final PresignedUrlListRequestDto requestList,
-                                 @NotNull final CloudFrontSettings settings) {
+                                 @NotNull final PresignedUrlSettings settings) {
     String multipartContentType = requestList.getMultipartContentType();
     final List<PresignedUrlDto> responses = requestList.getPresignedUrlRequests().stream().map(request -> {
       try {
         if (request.getDigests() != null && request.getDigests().size() > 1) {
           String uploadId;
           if (request.getUploadId() == null) {
-            uploadId = myPreSignedManager.startMultipartUpload(request.getObjectKey(), multipartContentType, settings);
+            uploadId = startMultipartUpload(request.getObjectKey(), multipartContentType, settings);
           } else {
             uploadId = request.getUploadId();
           }
@@ -264,7 +289,7 @@ public class S3PreSignedUrlController extends BaseController {
             final String digest = request.getDigests().get(i);
             int partNumber = i + 1;
             try {
-              final String url = myPreSignedManager.generateUploadUrlForPart(request.getObjectKey(), digest, partNumber, uploadId, settings);
+              final String url = generateUploadUrlForPart(request.getObjectKey(), digest, partNumber, uploadId, settings);
               presignedUrls.add(new PresignedUrlPartDto(url, partNumber));
             } catch (IOException e) {
               LOG.infoAndDebugDetails(() -> "Got exception while trying to generate presigned url for part: " + e.getMessage(), e);
@@ -273,10 +298,10 @@ public class S3PreSignedUrlController extends BaseController {
           }
           return PresignedUrlDto.multiPart(request.getObjectKey(), uploadId, presignedUrls);
         } else if (request.getNumberOfParts() > 1) {
-          final String uploadId = myPreSignedManager.startMultipartUpload(request.getObjectKey(), multipartContentType, settings);
+          final String uploadId = startMultipartUpload(request.getObjectKey(), multipartContentType, settings);
           final List<PresignedUrlPartDto> presignedUrls = IntStream.rangeClosed(1, request.getNumberOfParts()).mapToObj(partNumber -> {
             try {
-              return new PresignedUrlPartDto(myPreSignedManager.generateUploadUrlForPart(request.getObjectKey(), null, partNumber, uploadId, settings), partNumber);
+              return new PresignedUrlPartDto(generateUploadUrlForPart(request.getObjectKey(), null, partNumber, uploadId, settings), partNumber);
             } catch (IOException e) {
               LOG.infoAndDebugDetails(() -> "Got exception while trying to generate presigned url for part: " + e.getMessage(), e);
               throw new RuntimeException(e);
@@ -284,12 +309,12 @@ public class S3PreSignedUrlController extends BaseController {
           }).collect(Collectors.toList());
           return PresignedUrlDto.multiPart(request.getObjectKey(), uploadId, presignedUrls);
         } else if (request.getDigests() != null && request.getDigests().size() == 1) {
-          return PresignedUrlDto.singlePart(request.getObjectKey(), myPreSignedManager.generateUploadUrl(request.getObjectKey(), request.getDigests().get(0), settings));
+          return PresignedUrlDto.singlePart(request.getObjectKey(), generateUploadUrl(request.getObjectKey(), request.getDigests().get(0), settings));
         } else if (request.getHttpMethod() != null) {
-          PresignedUrlWithTtl presignedUrlWithTtl = myPreSignedManager.generateDownloadUrl(SdkHttpMethod.valueOf(request.getHttpMethod()), request.getObjectKey(), settings);
+          PresignedUrlWithTtl presignedUrlWithTtl = myPreSignedManager.generateDownloadUrl(SdkHttpMethod.valueOf(request.getHttpMethod()), request.getObjectKey(), settings.myCloudFrontSettings);
           return PresignedUrlDto.singlePart(request.getObjectKey(), presignedUrlWithTtl.getUrl());
         } else {
-          return PresignedUrlDto.singlePart(request.getObjectKey(), myPreSignedManager.generateUploadUrl(request.getObjectKey(), null, settings));
+          return PresignedUrlDto.singlePart(request.getObjectKey(), generateUploadUrl(request.getObjectKey(), null, settings));
         }
       } catch (Exception e) {
         LOG.infoAndDebugDetails(() -> "Got exception while trying to generate presigned url: " + e.getMessage(), e);
@@ -301,10 +326,10 @@ public class S3PreSignedUrlController extends BaseController {
 
   @NotNull
   private String presignedUrlsV1(@NotNull final PresignedUrlListRequestDto requests,
-                                 @NotNull final CloudFrontSettings settings) {
+                                 @NotNull final PresignedUrlSettings settings) {
     return serializeResponseV1(PresignedUrlListResponseDto.createV1(requests.getPresignedUrlRequests().stream().map(request -> {
       try {
-        return PresignedUrlDto.singlePart(request.getObjectKey(), myPreSignedManager.generateUploadUrl(request.getObjectKey(), null, settings));
+        return PresignedUrlDto.singlePart(request.getObjectKey(), generateUploadUrl(request.getObjectKey(), null, settings));
       } catch (IOException e) {
         LOG.infoAndDebugDetails("Got exception while generating presigned URL: " + e.getMessage(), e);
         throw new RuntimeException(e);
@@ -313,7 +338,7 @@ public class S3PreSignedUrlController extends BaseController {
   }
 
   private void finishMultipartUpload(@NotNull final HttpServletRequest httpServletRequest,
-                                     @NotNull final CloudFrontSettings settings) throws Exception {
+                                     @NotNull final PresignedUrlSettings settings) throws Exception {
     final String objectKeyBase64 = new String(getDecoder().decode(StringUtil.emptyIfNull(httpServletRequest.getParameter(OBJECT_KEY + "_BASE64"))), StandardCharsets.UTF_8);
     final String objectKey = StringUtil.isNotEmpty(objectKeyBase64) ? objectKeyBase64 : httpServletRequest.getParameter(OBJECT_KEY);
     if (StringUtil.isEmpty(objectKey)) {
@@ -328,7 +353,40 @@ public class S3PreSignedUrlController extends BaseController {
     if (isSuccessful && (eTags == null || eTags.length < 1)) {
       throw new HttpServerErrorException(HttpStatus.BAD_REQUEST, ETAGS + " should be present");
     }
-    myPreSignedManager.finishMultipartUpload(uploadId, objectKey, settings, eTags, isSuccessful);
+    if (settings.myUseS3ForUpload) {
+      myS3PreSignedManager.finishMultipartUpload(uploadId, objectKey, settings.myS3Settings, eTags, isSuccessful);
+    } else {
+      myPreSignedManager.finishMultipartUpload(uploadId, objectKey, settings.myCloudFrontSettings, eTags, isSuccessful);
+    }
+  }
+
+  @NotNull
+  private String generateUploadUrl(@NotNull String objectKey,
+                                   @Nullable String digest,
+                                   @NotNull PresignedUrlSettings settings) throws IOException {
+    return settings.myUseS3ForUpload
+           ? myS3PreSignedManager.generateUploadUrl(objectKey, digest, settings.myS3Settings)
+           : myPreSignedManager.generateUploadUrl(objectKey, digest, settings.myCloudFrontSettings);
+  }
+
+  @NotNull
+  private String generateUploadUrlForPart(@NotNull String objectKey,
+                                          @Nullable String digest,
+                                          int partNumber,
+                                          @NotNull String uploadId,
+                                          @NotNull PresignedUrlSettings settings) throws IOException {
+    return settings.myUseS3ForUpload
+           ? myS3PreSignedManager.generateUploadUrlForPart(objectKey, digest, partNumber, uploadId, settings.myS3Settings)
+           : myPreSignedManager.generateUploadUrlForPart(objectKey, digest, partNumber, uploadId, settings.myCloudFrontSettings);
+  }
+
+  @NotNull
+  private String startMultipartUpload(@NotNull String objectKey,
+                                      @Nullable String contentType,
+                                      @NotNull PresignedUrlSettings settings) throws Exception {
+    return settings.myUseS3ForUpload
+           ? myS3PreSignedManager.startMultipartUpload(objectKey, contentType, settings.myS3Settings)
+           : myPreSignedManager.startMultipartUpload(objectKey, contentType, settings.myCloudFrontSettings);
   }
 
   @Nullable
@@ -348,6 +406,22 @@ public class S3PreSignedUrlController extends BaseController {
     @NotNull
     public static RequestType fromRequest(@NotNull final HttpServletRequest request) {
       return StringUtil.isNotEmpty(request.getParameter(FINISH_UPLOAD)) ? FINISH_MULTIPART_UPLOAD : GENERATE_PRESIGNED_URLS;
+    }
+  }
+
+  private static class PresignedUrlSettings {
+    @NotNull
+    private final CloudFrontSettings myCloudFrontSettings;
+    @NotNull
+    private final S3Settings myS3Settings;
+    private final boolean myUseS3ForUpload;
+
+    private PresignedUrlSettings(@NotNull CloudFrontSettings cloudFrontSettings,
+                                 @NotNull S3Settings s3Settings,
+                                 boolean useS3ForUpload) {
+      myCloudFrontSettings = cloudFrontSettings;
+      myS3Settings = s3Settings;
+      myUseS3ForUpload = useS3ForUpload;
     }
   }
 }

--- a/s3-artifact-storage-server/src/main/resources/buildServerResources/s3_storage_settings_old_ui.jsp
+++ b/s3-artifact-storage-server/src/main/resources/buildServerResources/s3_storage_settings_old_ui.jsp
@@ -112,6 +112,12 @@
     </tr>
     <tbody id="${params.cloudFrontSettingsGroup}">
     <tr class="noBorder">
+      <th><label for="${params.cloudFrontUploadUseS3}">Use S3 for uploads: </label></th>
+      <td>
+        <props:checkboxProperty name="${params.cloudFrontUploadUseS3}" id="${params.cloudFrontUploadUseS3}"/>
+      </td>
+    </tr>
+    <tr class="noBorder" id="cloudFrontUploadDistributionRow">
       <th><label for="${cloudfrontUploadDistributionSelect}">Distribution for uploads: <l:star/></label></th>
       <td>
         <div class="posRel">
@@ -233,6 +239,8 @@
     var $createDistributionButton = $j(BS.Util.escapeId('${params.cloudFrontCreateDistribution}'));
     var $distributionUploadInput = $j(BS.Util.escapeId('${params.cloudFrontUploadDistribution}'));
     var $distributionUploadSelect = $j(BS.Util.escapeId('${cloudfrontUploadDistributionSelect}'));
+    var $cloudFrontUploadUseS3 = $j(BS.Util.escapeId('${params.cloudFrontUploadUseS3}'));
+    var $cloudFrontUploadDistributionRow = $j('#cloudFrontUploadDistributionRow');
     var $distributionDownloadInput = $j(BS.Util.escapeId('${params.cloudFrontDownloadDistribution}'));
     var $distributionDownloadSelect = $j(BS.Util.escapeId('${cloudfrontDownloadDistributionSelect}'));
 
@@ -481,6 +489,11 @@
       } else {
         BS.Util.hide('${params.cloudFrontSettingsGroup}');
       }
+      if ($cloudFrontUploadUseS3.is(':checked')) {
+        $cloudFrontUploadDistributionRow.hide();
+      } else {
+        $cloudFrontUploadDistributionRow.show();
+      }
     }
 
     $j(document).on('change', keyId + ', ' + keySecret, function () {
@@ -529,6 +542,9 @@
       redrawPrivateKeyUploader();
     });
     $j(BS.Util.escapeId('${params.cloudFrontEnabled}')).change(function () {
+      updateCloudFrontVisibility()
+    });
+    $cloudFrontUploadUseS3.change(function () {
       updateCloudFrontVisibility()
     });
 

--- a/s3-artifact-storage-server/src/main/resources/buildServerResources/s3_storage_settings_react_ui.jsp
+++ b/s3-artifact-storage-server/src/main/resources/buildServerResources/s3_storage_settings_react_ui.jsp
@@ -111,6 +111,7 @@
       bucketPathPrefix: "<bs:forJs>${propertiesBean.properties[params.pathPrefix]}</bs:forJs>",
 
       useCloudFront: "<bs:forJs>${propertiesBean.properties[params.cloudFrontEnabled]}</bs:forJs>" === "true",
+      cloudFrontUseS3Upload: "<bs:forJs>${propertiesBean.properties[params.cloudFrontUploadUseS3]}</bs:forJs>" === "true",
       cloudFrontUploadDistribution: "<bs:forJs>${propertiesBean.properties[params.cloudFrontUploadDistribution]}</bs:forJs>",
       cloudFrontDownloadDistribution: "<bs:forJs>${propertiesBean.properties[params.cloudFrontDownloadDistribution]}</bs:forJs>",
       cloudFrontPublicKeyId: "<bs:forJs>${propertiesBean.properties[params.cloudFrontPublicKeyId]}</bs:forJs>",

--- a/s3-artifact-storage-ui/src/App/S3/TransferSpeedUp/TransferSpeedUp.tsx
+++ b/s3-artifact-storage-ui/src/App/S3/TransferSpeedUp/TransferSpeedUp.tsx
@@ -1,5 +1,6 @@
 import { React } from '@jetbrains/teamcity-api';
 import {
+  FormCheckbox,
   Option,
   SectionHeader,
   Switcher,
@@ -29,12 +30,19 @@ import TrustedKeyGroup from './components/TrustedKeyGroup';
 
 function CloudFrontLoaderWrapper() {
   const { isInitialized } = useCloudFrontDistributionsContext();
+  const { control, watch } = useFormContext<IFormInput>();
+  const useS3Upload = watch(FormFields.CLOUD_FRONT_UPLOAD_USE_S3);
 
   if (isInitialized) {
     return (
       <>
         <DownloadDistribution />
-        <UploadDistribution />
+        <FormCheckbox
+          name={FormFields.CLOUD_FRONT_UPLOAD_USE_S3}
+          control={control}
+          label="Use S3 for uploads"
+        />
+        {!useS3Upload && <UploadDistribution />}
         <TrustedKeyGroup />
       </>
     );

--- a/s3-artifact-storage-ui/src/App/appConstants.tsx
+++ b/s3-artifact-storage-ui/src/App/appConstants.tsx
@@ -22,6 +22,7 @@ export enum FormFields {
   S3_BUCKET_NAME = 'prop:storage_s3_bucket_name',
   S3_BUCHET_PATH_PREFIX = 'prop:storage_s3_bucket_prefix',
   CLOUD_FRONT_TOGGLE = 'prop:storage_s3_cloudfront_enabled',
+  CLOUD_FRONT_UPLOAD_USE_S3 = 'prop:storage_s3_cloudfront_upload_s3_enabled',
   CLOUD_FRONT_UPLOAD_DISTRIBUTION = 'prop:storage_s3_cloudfront_upload_distribution',
   CLOUD_FRONT_DOWNLOAD_DISTRIBUTION = 'prop:storage_s3_cloudfront_download_distribution',
   CLOUD_FRONT_PUBLIC_KEY_ID = 'prop:storage_s3_cloudfront_publicKeyId',

--- a/s3-artifact-storage-ui/src/Utilities/parametersUtils.ts
+++ b/s3-artifact-storage-ui/src/Utilities/parametersUtils.ts
@@ -72,8 +72,11 @@ export function serializeParameters(
   if (!formData[FormFields.CLOUD_FRONT_TOGGLE]) {
     formData[FormFields.CLOUD_FRONT_DOWNLOAD_DISTRIBUTION] = undefined;
     formData[FormFields.CLOUD_FRONT_UPLOAD_DISTRIBUTION] = undefined;
+    formData[FormFields.CLOUD_FRONT_UPLOAD_USE_S3] = undefined;
     formData[FormFields.CLOUD_FRONT_PUBLIC_KEY_ID] = undefined;
     formData[FormFields.CLOUD_FRONT_PRIVATE_KEY] = undefined;
+  } else if (formData[FormFields.CLOUD_FRONT_UPLOAD_USE_S3]) {
+    formData[FormFields.CLOUD_FRONT_UPLOAD_DISTRIBUTION] = undefined;
   }
   if (formData[FormFields.STORAGE_TYPE]?.key === AWS_S3 && awsConnectionKey) {
     formData[FormFields.ACCESS_KEY_ID] = undefined;

--- a/s3-artifact-storage-ui/src/contexts/AppContext.tsx
+++ b/s3-artifact-storage-ui/src/contexts/AppContext.tsx
@@ -30,6 +30,7 @@ const AppContext = React.createContext<Config>({
   bucket: '',
   bucketPathPrefix: '',
   useCloudFront: false,
+  cloudFrontUseS3Upload: false,
   cloudFrontUploadDistribution: '',
   cloudFrontDownloadDistribution: '',
   cloudFrontPublicKeyId: '',

--- a/s3-artifact-storage-ui/src/hooks/useS3Form.tsx
+++ b/s3-artifact-storage-ui/src/hooks/useS3Form.tsx
@@ -84,6 +84,7 @@ export default function useS3Form() {
       [FormFields.S3_BUCKET_NAME]: config.bucket,
       [FormFields.S3_BUCHET_PATH_PREFIX]: config.bucketPathPrefix,
       [FormFields.CLOUD_FRONT_TOGGLE]: config.useCloudFront,
+      [FormFields.CLOUD_FRONT_UPLOAD_USE_S3]: config.cloudFrontUseS3Upload,
       [FormFields.CLOUD_FRONT_PRIVATE_KEY]: config.cloudFrontPrivateKey,
       [FormFields.CONNECTION_PRESIGNED_URL_TOGGLE]:
         config.usePresignUrlsForUpload,

--- a/s3-artifact-storage-ui/src/types/index.ts
+++ b/s3-artifact-storage-ui/src/types/index.ts
@@ -34,6 +34,7 @@ export type Config = {
   bucket: string;
   bucketPathPrefix: string;
   useCloudFront: boolean;
+  cloudFrontUseS3Upload: boolean;
   cloudFrontUploadDistribution: string;
   cloudFrontDownloadDistribution: string;
   cloudFrontPublicKeyId: string;
@@ -73,6 +74,7 @@ export interface S3FormInput {
   [FormFields.S3_BUCKET_NAME]: string | Option;
   [FormFields.S3_BUCHET_PATH_PREFIX]: string;
   [FormFields.CLOUD_FRONT_TOGGLE]: boolean;
+  [FormFields.CLOUD_FRONT_UPLOAD_USE_S3]: boolean;
   [FormFields.CLOUD_FRONT_UPLOAD_DISTRIBUTION]: DistributionItem;
   [FormFields.CLOUD_FRONT_DOWNLOAD_DISTRIBUTION]: DistributionItem;
   [FormFields.CLOUD_FRONT_PUBLIC_KEY_ID]: Option;


### PR DESCRIPTION
This patch supports an option of having the CloudFront support only used when downloading assets and leaves the uploading as going to the S3 storage.